### PR TITLE
Adds functionality to add cuisine preferences to user array

### DIFF
--- a/client/src/components/Cuisine/cuisineDropDown.jsx
+++ b/client/src/components/Cuisine/cuisineDropDown.jsx
@@ -9,6 +9,7 @@ export default function CuisineDropDown() {
   const { loading, error, data } = useQuery(QUERY_ALL_CUISINES);
   const [addCuisine] = useMutation(ADD_CUISINE);
   const [selectedCuisines, setSelectedCuisines] = useState([]);
+
   const handleCheckboxChange = (event) => {
     const { id, checked } = event.target;
     const cuisine = {
@@ -25,7 +26,7 @@ export default function CuisineDropDown() {
 
   const handleSubmit = async (event) => {
     event.preventDefault();
-    console.dir(selectedCuisines)
+
     try {
       const { data } = await addCuisine({
         variables: { cuisineData: selectedCuisines },
@@ -35,6 +36,8 @@ export default function CuisineDropDown() {
     } catch (error) {
       console.log(`Error saving food preferences: ${error.message}`);
     }
+
+    setSelectedCuisines([]);
   };
 
   if (loading) return <p>Loading...</p>;

--- a/client/src/components/Cuisine/cuisineDropDown.jsx
+++ b/client/src/components/Cuisine/cuisineDropDown.jsx
@@ -1,3 +1,6 @@
+// This component needs Auth added to keep unauthenticated users from accessing the page.
+
+import React, { useState } from "react";
 import { useQuery, useMutation } from "@apollo/client";
 import { QUERY_ALL_CUISINES } from "../../utils/queries";
 import { ADD_CUISINE } from "../../utils/mutations";
@@ -5,24 +8,29 @@ import { ADD_CUISINE } from "../../utils/mutations";
 export default function CuisineDropDown() {
   const { loading, error, data } = useQuery(QUERY_ALL_CUISINES);
   const [addCuisine] = useMutation(ADD_CUISINE);
+  const [selectedCuisines, setSelectedCuisines] = useState([]);
+  const handleCheckboxChange = (event) => {
+    const { id, checked } = event.target;
+    const cuisine = {
+      name: event.target.value,
+      cuisineId: id,
+    };
+
+    setSelectedCuisines((prevSelectedCuisines) =>
+      checked
+        ? [...prevSelectedCuisines, cuisine]
+        : prevSelectedCuisines.filter((c) => c.cuisineId !== id)
+    );
+  };
 
   const handleSubmit = async (event) => {
     event.preventDefault();
-
-    const selectedCuisines = Array.from(event.target.elements)
-      .filter((el) => el.type === "checkbox" && el.checked)
-      .map((el) => ({
-        name: el.value,
-        cuisineId: el.id,
-      }));
-
-    console.log("Mutation variables:", selectedCuisines);
-
+    console.dir(selectedCuisines)
     try {
       const { data } = await addCuisine({
         variables: { cuisineData: selectedCuisines },
       });
-      console.log("Saved cuisines:", data.addCuisine);
+      console.log("Saved cuisines:", data);
       alert("Food preferences successfully saved!");
     } catch (error) {
       console.log(`Error saving food preferences: ${error.message}`);
@@ -31,11 +39,7 @@ export default function CuisineDropDown() {
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error: {error.message}</p>;
-
   const cuisines = data.allCuisines;
-
-  console.log("Cuisines:", cuisines);
-
   return (
     <div>
       <h3>Select your preferred cuisines:</h3>
@@ -46,12 +50,22 @@ export default function CuisineDropDown() {
               type="checkbox"
               id={cuisine.cuisineId}
               value={cuisine.name}
+              onChange={handleCheckboxChange}
+              checked={selectedCuisines.some((c) => c.cuisineId === cuisine.cuisineId)}
             />
             <label htmlFor={cuisine.cuisineId}>{cuisine.name}</label>
           </div>
         ))}
         <button type="submit">Save</button>
       </form>
+      <h3>Selected preferences:</h3>
+      <ul>
+        {selectedCuisines.map((cuisine) => (
+          <li key={cuisine.cuisineId}>
+            {cuisine.name} - {cuisine.cuisineId}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/client/src/utils/mutations.js
+++ b/client/src/utils/mutations.js
@@ -25,8 +25,8 @@ export const LOGIN = gql`
 `;
 
 export const ADD_CUISINE = gql`
-  mutation addCuisine($name: String!, $cuisineId: String!) {
-    addCuisine(name: $name, cuisineId: $cuisineId) {
+  mutation addCuisine($cuisineData: [CuisineInput!]) {
+    addCuisine(cuisineData: $cuisineData) {
       _id
       username
       savedCuisines {
@@ -37,18 +37,18 @@ export const ADD_CUISINE = gql`
   }
 `;
 
-// export const REMOVE_CUISINE = gql`
-//   mutation removeCuisine($cuisineData: CuisineInput!) {
-//     removeCuisine(cuisineData: $cuisineData) {
-//       _id
-//       username
-//       savedCuisines {
-//         cuisineId
-//         name
-//       }
-//     }
-//   }
-// `;
+export const REMOVE_CUISINE = gql`
+  mutation removeCuisine($cuisineData: CuisineInput!) {
+    removeCuisine(cuisineData: $cuisineData) {
+      _id
+      username
+      savedCuisines {
+        cuisineId
+        name
+      }
+    }
+  }
+`;
 
 export const CREATE_RESTAURANT = gql`
   mutation createRestaurant(

--- a/client/src/utils/mutations.js
+++ b/client/src/utils/mutations.js
@@ -25,8 +25,8 @@ export const LOGIN = gql`
 `;
 
 export const ADD_CUISINE = gql`
-  mutation addCuisine($cuisineData: CuisineInput!) {
-    addCuisine(cuisineData: $cuisineData) {
+  mutation addCuisine($name: String!, $cuisineId: String!) {
+    addCuisine(name: $name, cuisineId: $cuisineId) {
       _id
       username
       savedCuisines {
@@ -37,18 +37,18 @@ export const ADD_CUISINE = gql`
   }
 `;
 
-export const REMOVE_CUISINE = gql`
-  mutation removeCuisine($cuisineData: CuisineInput!) {
-    removeCuisine(cuisineData: $cuisineData) {
-      _id
-      username
-      savedCuisines {
-        cuisineId
-        name
-      }
-    }
-  }
-`;
+// export const REMOVE_CUISINE = gql`
+//   mutation removeCuisine($cuisineData: CuisineInput!) {
+//     removeCuisine(cuisineData: $cuisineData) {
+//       _id
+//       username
+//       savedCuisines {
+//         cuisineId
+//         name
+//       }
+//     }
+//   }
+// `;
 
 export const CREATE_RESTAURANT = gql`
   mutation createRestaurant(

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -27,7 +27,12 @@ const userSchema = new Schema(
         ref: "Restaurant",
       },
     ],
-    savedCuisines: [{ type: Schema.Types.ObjectId, ref: "Cuisine" }],
+    savedCuisines: [
+      {
+      name: String,
+      cuisineId: String,
+      }
+    ],
   },
   {
     toJSON: {

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -81,6 +81,8 @@ const resolvers = {
     },
 
     addCuisine: async (parent, { cuisineData }, context) => {
+      console.log(cuisineData);
+
       if (context.user) {
         const updatedUser = await User.findByIdAndUpdate(
           { _id: context.user._id },
@@ -92,7 +94,7 @@ const resolvers = {
       throw AuthenticationError;
     },
 
-    removeCuisine: async (parent, { cuisineData }, context) => {
+    removeCuisine: async (parent, { cuisineId }, context) => {
       if (context.user) {
         const updatedUser = await User.findByIdAndUpdate(
           { _id: context.user._id },

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -84,13 +84,24 @@ const resolvers = {
     addCuisine: async (parent, { cuisineData }, context) => {
       
       if (context.user) {
+
+        const user = await User.findById(context.user._id);
+        const existingCusines = user.savedCuisines.map(cuisine => cuisine.cuisineId);
+
+        const updatedCuisines = cuisineData.filter(cuisine => !existingCusines.includes(cuisine.cuisineId));
+        console.log(updatedCuisines);
+
+        if (updatedCuisines.length > 0) {
         const updatedUser = await User.findByIdAndUpdate(
           { _id: context.user._id },
-          { $push: { savedCuisines: cuisineData } },
+          { $push: { savedCuisines: updatedCuisines } },
           { new: true }
         );
         return updatedUser;
+      } else {
+        return user
       }
+    }
       throw AuthenticationError;
     },
 
@@ -98,7 +109,7 @@ const resolvers = {
       if (context.user) {
         const updatedUser = await User.findByIdAndUpdate(
           { _id: context.user._id },
-          { $pull: { savedCuisines: { cuisineId } } },
+          { $addToSet: { savedCuisines: { cuisineId } } },
           { new: true }
         );
         return updatedUser;

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -80,10 +80,9 @@ const resolvers = {
       return restaurant;
     },
 
-    // The arguments are just that and can be named what we want.  The order is what's important.
+    
     addCuisine: async (parent, { cuisineData }, context) => {
-      console.log(cuisineData);
-
+      
       if (context.user) {
         const updatedUser = await User.findByIdAndUpdate(
           { _id: context.user._id },

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -80,6 +80,7 @@ const resolvers = {
       return restaurant;
     },
 
+    // The arguments are just that and can be named what we want.  The order is what's important.
     addCuisine: async (parent, { cuisineData }, context) => {
       console.log(cuisineData);
 

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -3,7 +3,7 @@ const { gql } = require("apollo-server-express");
 const typeDefs = gql`
   type Cuisine {
     name: String!
-    cuisineId: ID!
+    cuisineId: String!
   }
 
   type Restaurant {
@@ -45,17 +45,19 @@ const typeDefs = gql`
     cuisine(name: String!): Cuisine
   }
 
-  input CuisineInput {
-    name: String
-    cuisineId: ID!
-  }
+  # input CuisineInput {
+  #   name: String
+  #   cuisineId: String
+  # }
 
   type Mutation {
     createUser(username: String!, password: String!): Auth
 
     login(username: String!, password: String!): Auth
 
-    addCuisine(cuisineData: CuisineInput!): User
+    # addCuisine(cuisineData: CuisineInput!): User
+
+    addCuisine(name: String!, cuisineId: String!): User
 
     removeCuisine(cuisineId: ID!): User
 

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -45,19 +45,19 @@ const typeDefs = gql`
     cuisine(name: String!): Cuisine
   }
 
-  # input CuisineInput {
-  #   name: String
-  #   cuisineId: String
-  # }
+  input CuisineInput {
+    name: String
+    cuisineId: String
+  }
 
   type Mutation {
     createUser(username: String!, password: String!): Auth
 
     login(username: String!, password: String!): Auth
 
-    # addCuisine(cuisineData: CuisineInput!): User
+    addCuisine(cuisineData: [CuisineInput!]): User
 
-    addCuisine(name: String!, cuisineId: String!): User
+    # addCuisine(name: String!, cuisineId: String!): User
 
     removeCuisine(cuisineId: ID!): User
 

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -57,8 +57,6 @@ const typeDefs = gql`
 
     addCuisine(cuisineData: [CuisineInput!]): User
 
-    # addCuisine(name: String!, cuisineId: String!): User
-
     removeCuisine(cuisineId: ID!): User
 
     createRestaurant(


### PR DESCRIPTION
This PR adds functionality to allow users to save their cuisine preferences.  An input type is defined in the `typeDefs` to allow the use of an array of cuisine objects with the `name` and `cuisineId` fields.   An important change to the User model was made to allow the array to populate correctly.  Specific fields for the `name` and `cuisineId` were added to replace the object Id it was previously expecting.  Cuisine could be changed to a schema type to condense code and be used as a reference in the User model, but it has been left as a model to allow data to seed properly for the front-end elements.  The variable in `cuisinedropdown.jsx` was also updated to no longer pass an empty object.